### PR TITLE
Get the save path for the excel from an environment variable.

### DIFF
--- a/app/jobs/responses_excel_job.rb
+++ b/app/jobs/responses_excel_job.rb
@@ -30,12 +30,12 @@ class ResponsesExcelJob < Struct.new(:survey, :response_ids, :organization_names
         end
       end
     end
-    f = File.open(Rails.root.join('public', filename), 'w')
+    f = File.open(excel_save_path.join(filename), 'w')
     package.serialize(f)
   end
 
   def after(job)
-    delete_excel if FileTest.exists?(Rails.root.join('public', filename))
+    delete_excel if FileTest.exists?(excel_save_path.join(filename))
   end
 
   def error(job, exception)
@@ -45,7 +45,15 @@ class ResponsesExcelJob < Struct.new(:survey, :response_ids, :organization_names
   private
 
   def delete_excel
-    File.delete Rails.root.join('public', filename)
+    File.delete excel_save_path.join(filename)
   end
   handle_asynchronously :delete_excel, :run_at => Proc.new { 30.minutes.from_now }, :queue => 'delete_excel'
+
+  def excel_save_path
+    if(FileTest.writable?(ENV['EXCEL_SAVE_PATH'].to_s))
+      Pathname.new(ENV['EXCEL_SAVE_PATH'])
+    else
+      Rails.root.join("public")
+    end
+  end
 end

--- a/config/application.yml.example
+++ b/config/application.yml.example
@@ -1,3 +1,4 @@
 OAUTH_ID: # Application ID of the OAuth provider.
 OAUTH_SECRET: # Secret of the OAuth provider.
 OAUTH_SERVER_URL: # URL where the OAuth Provider instance is hosted.
+EXCEL_SAVE_PATH: "/Path/To/Rails/Root/public"


### PR DESCRIPTION
- Engineyard creates a new release directory for each deploy
- If the server isn't restarted, `Rails.root` points to the old directory
- Excel generation fails because we use `Rails.root` to get the directory to save into.

This pull-request allows setting the excel-save-directory using application.yml
We should set the excel save directory as `/data/surveyweb/current/public`
