### PR TITLE
HTTPS Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ db/database.yml
 public/uploads
 zeus.json
 custom_plan.rb
+.powenv

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'paperclip'
 gem 'feature'
 gem "active_model_serializers", "~> 0.7.0"
 gem 'jquery-rails'
+gem 'rack-ssl', :require => 'rack/ssl'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,6 @@ gem 'paperclip'
 gem 'feature'
 gem "active_model_serializers", "~> 0.7.0"
 gem 'jquery-rails'
-gem 'rack-ssl', :require => 'rack/ssl'
 
 # Gems used only for assets and not required
 # in production environments by default.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,6 +325,7 @@ DEPENDENCIES
   pry-rails
   quiet_assets
   rack-mini-profiler
+  rack-ssl
   railroady (~> 1.1.0)
   rails (= 3.2.13)
   rails-backbone

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,7 +325,6 @@ DEPENDENCIES
   pry-rails
   quiet_assets
   rack-mini-profiler
-  rack-ssl
   railroady (~> 1.1.0)
   rails (= 3.2.13)
   rails-backbone

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -2,6 +2,7 @@ require 'will_paginate/array'
 
 class SurveysController < ApplicationController
   load_and_authorize_resource
+  before_filter :redirect_to_https, :only => :index
 
   def index
     @surveys ||= Survey.none
@@ -70,11 +71,9 @@ class SurveysController < ApplicationController
 
   private
 
-  def require_draft_survey
-    survey = Survey.find(params[:survey_id])
-    if survey.finalized?
-      flash[:error] = t "flash.edit_finalized_survey"
-      redirect_to root_path
-    end
+  def redirect_to_https
+    # Need request.head? because mobile makes a HEAD request to this same path and Titanium
+    # since doesn't follow redirects, we can't redirect to https:// in that case.
+    redirect_to :protocol => "https://" if !request.ssl? && !request.head?
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,5 +37,7 @@ SurveyWeb::Application.configure do
   config.assets.debug = true
 
   Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+
+  config.middleware.insert_before ActionDispatch::Static, Rack::SSL, :exclude => proc { |env| env['HTTPS'] != 'on' }
 end
 ""

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,9 +36,7 @@ SurveyWeb::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  #config.force_ssl = true
-
-  config.middleware.insert_before ActionDispatch::Static, Rack::SSL, :exclude => proc { |env| env['HTTPS'] != 'on' }
+  config.force_ssl = true
 
   # See everything in the log (default is :info)
   # config.log_level = :debug

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,7 @@ SurveyWeb::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # See everything in the log (default is :info)
   # config.log_level = :debug

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,9 @@ SurveyWeb::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  #config.force_ssl = true
+
+  config.middleware.insert_before ActionDispatch::Static, Rack::SSL, :exclude => proc { |env| env['HTTPS'] != 'on' }
 
   # See everything in the log (default is :info)
   # config.log_level = :debug

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -36,7 +36,8 @@ SurveyWeb::Application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for nginx
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  #config.force_ssl = true
+  config.middleware.insert_before ActionDispatch::Static, Rack::SSL, :exclude => proc { |env| env['HTTPS'] != 'on' }
 
   # See everything in the log (default is :info)
   # config.log_level = :debug

--- a/spec/controllers/surveys_controller_spec.rb
+++ b/spec/controllers/surveys_controller_spec.rb
@@ -5,6 +5,7 @@ describe SurveysController do
 
   context "GET 'index'" do
     before(:each) do
+      request.env['HTTPS'] = 'on'
       session[:access_token] = "123"
       response = mock(OAuth2::Response)
       access_token = mock(OAuth2::AccessToken)
@@ -57,6 +58,21 @@ describe SurveysController do
         get :index
         response.should be_ok
         assigns(:surveys).should include @finalized_survey
+      end
+    end
+
+    context "when redirecting to a https:// url" do
+      it "redirects if the request is http://" do
+        request.env['HTTPS'] = 'off'
+        get :index
+        response.should be_a_redirect
+        URI(response.location).scheme.should == "https"
+      end
+
+      it "doesn't redirect if the request is a HEAD request" do
+        request.env['HTTPS'] = 'off'
+        head :index
+        response.should_not be_a_redirect
       end
     end
   end


### PR DESCRIPTION
Two approaches.
## Redirect all HTTP requests to HTTPS
- Use `config.force_ssl = true`
- Mobile needs to update its server URL to a HTTPS URL.
- This can be done using an update
- Mobiles without the updated URL will fail all API calls (no data loss - "Please check your internet connection and try again"). This is because Titanium doesn't follow the redirect to HTTPS.
- Its unreasonable to expect all mobiles to have the latest update, so this approach is not going to work.
## No HTTPS unless https:// is Explicitly Mentioned
- Use this setting in `production.rb`

``` ruby
config.middleware.insert_before ActionDispatch::Static, Rack::SSL, :exclude => proc { |env| env['HTTPS'] != 'on' }
```
- Requests with `http://` will stay on `http://`. Requests with `https://` will use SSL.
- Existing mobiles will work okay even with the old URL. Their requests will _not_ use SSL until they get the update.
- However on web, going to `http://thesurveys.org/` and logging in will **_not**_ work (the OAuth callback uses `https://`)
- To get around this, we can redirect just the `root_path` (surveys index page) to `https://` regardless of the request.
- This way web users will be forced to use SSL, but mobile users on older builds can continue using HTTP until they upgrade.
